### PR TITLE
Use Afero Filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # pdfcpu: a golang pdf processor
 
 [![Build Status](https://travis-ci.org/hhrutter/pdfcpu.svg?branch=master)](https://travis-ci.org/hhrutter/pdfcpu)
-[![GoDoc](https://godoc.org/github.com/hhrutter/pdfcpu?status.svg)](https://godoc.org/github.com/hhrutter/pdfcpu)
+[![GoDoc](https://godoc.org/github.com/trussworks/pdfcpu?status.svg)](https://godoc.org/github.com/trussworks/pdfcpu)
 [![Coverage Status](https://coveralls.io/repos/github/hhrutter/pdfcpu/badge.svg?branch=master)](https://coveralls.io/github/hhrutter/pdfcpu?branch=master)
-[![Go Report Card](https://goreportcard.com/badge/github.com/hhrutter/pdfcpu)](https://goreportcard.com/report/github.com/hhrutter/pdfcpu)
+[![Go Report Card](https://goreportcard.com/badge/github.com/trussworks/pdfcpu)](https://goreportcard.com/report/github.com/trussworks/pdfcpu)
 [![License: MIT](https://img.shields.io/github/license/mashape/apistatus.svg)](https://opensource.org/licenses/MIT)
 
 ![logo](resources/pdfchip3.png)
@@ -49,7 +49,7 @@ Reducing the size of large PDF files for mass mailings by optimization to the ba
 
 Required build version: go1.8 and up
 
-`go get github.com/hhrutter/pdfcpu/cmd/...`
+`go get github.com/trussworks/pdfcpu/cmd/...`
 
 ## Usage
     
@@ -75,7 +75,7 @@ Required build version: go1.8 and up
 
     pdfcpu version
 
- [Please read the documentation](https://godoc.org/github.com/hhrutter/pdfcpu)
+ [Please read the documentation](https://godoc.org/github.com/trussworks/pdfcpu)
 
 
 ## Contributing

--- a/cmd/pdfcpu/main.go
+++ b/cmd/pdfcpu/main.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/hhrutter/pdfcpu/pkg/api"
-	PDFCPULog "github.com/hhrutter/pdfcpu/pkg/log"
-	"github.com/hhrutter/pdfcpu/pkg/pdfcpu"
+	"github.com/trussworks/pdfcpu/pkg/api"
+	PDFCPULog "github.com/trussworks/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/pdfcpu"
 )
 
 var (

--- a/cmd/pdfcpu/prepare.go
+++ b/cmd/pdfcpu/prepare.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/hhrutter/pdfcpu/pkg/api"
-	"github.com/hhrutter/pdfcpu/pkg/pdfcpu"
+	"github.com/trussworks/pdfcpu/pkg/api"
+	"github.com/trussworks/pdfcpu/pkg/pdfcpu"
 )
 
 func prepareValidateCommand(config *pdfcpu.Configuration) *api.Command {

--- a/coverage.sh
+++ b/coverage.sh
@@ -10,7 +10,7 @@ function internalDeps {
 
     for p in $(go list -f '{{.Deps}}' $1)
     do
-        if [[ $p == github.com/hhrutter/pdfcpu* ]]; then
+        if [[ $p == github.com/trussworks/pdfcpu* ]]; then
             idep=$idep,$p 
         fi
     done

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
-	"github.com/hhrutter/pdfcpu/pkg/pdfcpu"
+	"github.com/trussworks/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/pdfcpu"
 
 	"github.com/pkg/errors"
 

--- a/pkg/api/process.go
+++ b/pkg/api/process.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"github.com/hhrutter/pdfcpu/pkg/pdfcpu"
+	"github.com/trussworks/pdfcpu/pkg/pdfcpu"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/api/process_test.go
+++ b/pkg/api/process_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
-	"github.com/hhrutter/pdfcpu/pkg/pdfcpu"
+	"github.com/trussworks/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/pdfcpu"
 
 	"github.com/spf13/afero"
 )

--- a/pkg/api/process_test.go
+++ b/pkg/api/process_test.go
@@ -3,13 +3,14 @@ package api
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/hhrutter/pdfcpu/pkg/log"
 	"github.com/hhrutter/pdfcpu/pkg/pdfcpu"
+
+	"github.com/spf13/afero"
 )
 
 const outputDir = "testdata/out"
@@ -344,13 +345,13 @@ func TestGetPageCount(t *testing.T) {
 // Validate all PDFs in testdata.
 func TestValidateCommand(t *testing.T) {
 
-	files, err := ioutil.ReadDir("testdata")
+	config := pdfcpu.NewDefaultConfiguration()
+	config.ValidationMode = pdfcpu.ValidationRelaxed
+
+	files, err := afero.ReadDir(config.FileSystem, "testdata")
 	if err != nil {
 		t.Fatalf("TestValidateCommand: %v\n", err)
 	}
-
-	config := pdfcpu.NewDefaultConfiguration()
-	config.ValidationMode = pdfcpu.ValidationRelaxed
 
 	for _, file := range files {
 		if strings.HasSuffix(file.Name(), "pdf") {
@@ -392,12 +393,13 @@ func BenchmarkValidateCommand(b *testing.B) {
 // Optimize all PDFs in testdata and write with (default) end of line sequence "\n".
 func TestOptimizeCommandWithLF(t *testing.T) {
 
-	files, err := ioutil.ReadDir("testdata")
+	config := pdfcpu.NewDefaultConfiguration()
+
+	files, err := afero.ReadDir(config.FileSystem, "testdata")
 	if err != nil {
 		t.Fatalf("TestOptimizeCommandWithLF: %v\n", err)
 	}
 
-	config := pdfcpu.NewDefaultConfiguration()
 	log.SetDefaultLoggers()
 
 	// this is not necessary but to make it clearer.
@@ -421,12 +423,13 @@ func TestOptimizeCommandWithLF(t *testing.T) {
 // Optimize all PDFs in testdata and write with end of line sequence "\r".
 func TestOptimizeCommandWithCR(t *testing.T) {
 
-	files, err := ioutil.ReadDir("testdata")
+	config := pdfcpu.NewDefaultConfiguration()
+
+	files, err := afero.ReadDir(config.FileSystem, "testdata")
 	if err != nil {
 		t.Fatalf("TestOptimizeCommandWithCR: %v\n", err)
 	}
 
-	config := pdfcpu.NewDefaultConfiguration()
 	config.Eol = pdfcpu.EolCR
 
 	for _, file := range files {
@@ -451,15 +454,15 @@ func TestOptimizeCommandWithCR(t *testing.T) {
 // This test writes out the cross reference table the old way without using object streams and an xref stream.
 func TestOptimizeCommandWithCRAndNoXrefStream(t *testing.T) {
 
-	files, err := ioutil.ReadDir("testdata")
-	if err != nil {
-		t.Fatalf("TestOptimizeCommandWithCRAndNoXrefStream: %v\n", err)
-	}
-
 	config := pdfcpu.NewDefaultConfiguration()
 	config.Eol = pdfcpu.EolCR
 	config.WriteObjectStream = false
 	config.WriteXRefStream = false
+
+	files, err := afero.ReadDir(config.FileSystem, "testdata")
+	if err != nil {
+		t.Fatalf("TestOptimizeCommandWithCRAndNoXrefStream: %v\n", err)
+	}
 
 	for _, file := range files {
 		if strings.HasSuffix(file.Name(), "pdf") {
@@ -475,14 +478,14 @@ func TestOptimizeCommandWithCRAndNoXrefStream(t *testing.T) {
 // Optimize all PDFs in testdata and write with end of line sequence "\r\n".
 func TestOptimizeCommandWithCRLF(t *testing.T) {
 
-	files, err := ioutil.ReadDir("testdata")
-	if err != nil {
-		t.Fatalf("TestOptimizeCommmand: %v\n", err)
-	}
-
 	config := pdfcpu.NewDefaultConfiguration()
 	config.Eol = pdfcpu.EolCRLF
 	config.StatsFileName = outputDir + "/testStats.csv"
+
+	files, err := afero.ReadDir(config.FileSystem, "testdata")
+	if err != nil {
+		t.Fatalf("TestOptimizeCommmand: %v\n", err)
+	}
 
 	for _, file := range files {
 		if strings.HasSuffix(file.Name(), "pdf") {
@@ -507,7 +510,9 @@ func TestSplitCommand(t *testing.T) {
 // Merge all PDFs in testdir into out/test.pdf.
 func TestMergeCommand(t *testing.T) {
 
-	files, err := ioutil.ReadDir("testdata")
+	config := pdfcpu.NewDefaultConfiguration()
+
+	files, err := afero.ReadDir(config.FileSystem, "testdata")
 	if err != nil {
 		t.Fatalf("TestMergeCommmand: %v\n", err)
 	}
@@ -519,7 +524,7 @@ func TestMergeCommand(t *testing.T) {
 		}
 	}
 
-	_, err = Process(MergeCommand(inFiles, outputDir+"/test.pdf", pdfcpu.NewDefaultConfiguration()))
+	_, err = Process(MergeCommand(inFiles, outputDir+"/test.pdf", config))
 	if err != nil {
 		t.Fatalf("TestMergeCommand: %v\n", err)
 	}
@@ -538,14 +543,14 @@ func TestTrimCommand(t *testing.T) {
 
 func TestExtractImagesCommand(t *testing.T) {
 
-	files, err := ioutil.ReadDir("testdata")
+	config := pdfcpu.NewDefaultConfiguration()
+
+	files, err := afero.ReadDir(config.FileSystem, "testdata")
 	if err != nil {
 		t.Fatalf("TestExtractImagesCommand: %v\n", err)
 	}
 
-	c := pdfcpu.NewDefaultConfiguration()
-
-	cmd := ExtractImagesCommand("", outputDir, nil, c)
+	cmd := ExtractImagesCommand("", outputDir, nil, config)
 
 	for _, file := range files {
 

--- a/pkg/api/regexp_test.go
+++ b/pkg/api/regexp_test.go
@@ -6,7 +6,7 @@ import (
 
 	"strings"
 
-	"github.com/hhrutter/pdfcpu/pkg/pdfcpu"
+	"github.com/trussworks/pdfcpu/pkg/pdfcpu"
 )
 
 var r *regexp.Regexp

--- a/pkg/compress/lzw/lzw_test.go
+++ b/pkg/compress/lzw/lzw_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hhrutter/pdfcpu/pkg/compress/lzw"
+	"github.com/trussworks/pdfcpu/pkg/compress/lzw"
 )
 
 func compareToGolden(t *testing.T, b []byte, fileName string) {

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hhrutter/pdfcpu/pkg/filter"
+	"github.com/trussworks/pdfcpu/pkg/filter"
 )
 
 // Encode a test string twice with same filter

--- a/pkg/filter/flateDecode.go
+++ b/pkg/filter/flateDecode.go
@@ -5,7 +5,7 @@ import (
 	"compress/zlib"
 	"io"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/filter/lzwDecode.go
+++ b/pkg/filter/lzwDecode.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/hhrutter/pdfcpu/pkg/compress/lzw"
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/compress/lzw"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/array.go
+++ b/pkg/pdfcpu/array.go
@@ -5,7 +5,7 @@ import (
 
 	"strings"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 )
 
 // PDFArray represents a PDF array object.

--- a/pkg/pdfcpu/attach.go
+++ b/pkg/pdfcpu/attach.go
@@ -3,8 +3,8 @@ package pdfcpu
 import (
 	"os"
 
-	"github.com/hhrutter/pdfcpu/pkg/filter"
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/filter"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/attach.go
+++ b/pkg/pdfcpu/attach.go
@@ -1,12 +1,15 @@
 package pdfcpu
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/hhrutter/pdfcpu/pkg/filter"
 	"github.com/hhrutter/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
+)
+
+import (
+	"github.com/spf13/afero"
 )
 
 func decodedFileSpecStreamDict(xRefTable *XRefTable, fileName string, o PDFObject) (*PDFStreamDict, error) {
@@ -86,7 +89,7 @@ func extractAttachedFiles(ctx *PDFContext, files StringSet) error {
 
 		// TODO Refactor into returning only stream object numbers for files to be extracted.
 		// No writing to file in library!
-		err = ioutil.WriteFile(path, sd.Content, os.ModePerm)
+		err = afero.WriteFile(ctx.FileSystem, path, sd.Content, os.ModePerm)
 		if err != nil {
 			return err
 		}

--- a/pkg/pdfcpu/configuration.go
+++ b/pkg/pdfcpu/configuration.go
@@ -1,5 +1,9 @@
 package pdfcpu
 
+import (
+	"github.com/spf13/afero"
+)
+
 const (
 
 	// ValidationStrict ensures 100% compliance with the spec (PDF 32000-1:2008).
@@ -96,6 +100,9 @@ type Configuration struct {
 	// Supplied user access permissions, see Table 22
 	UserAccessPermissions int16
 
+	// Afero FileSystem to use
+	FileSystem afero.Fs
+
 	// Command being executed.
 	Mode CommandMode
 }
@@ -114,6 +121,25 @@ func NewDefaultConfiguration() *Configuration {
 		EncryptUsingAES:       true,
 		EncryptUsing128BitKey: true,
 		UserAccessPermissions: PermissionsNone,
+		FileSystem:            afero.NewOsFs(),
+	}
+}
+
+// NewInMemoryConfiguration returns a pdfcpu configuration with an in-memory filesystem.
+func NewInMemoryConfiguration() *Configuration {
+
+	return &Configuration{
+		Reader15:              true,
+		DecodeAllStreams:      false,
+		ValidationMode:        ValidationRelaxed,
+		Eol:                   EolLF,
+		WriteObjectStream:     true,
+		WriteXRefStream:       true,
+		CollectStats:          true,
+		EncryptUsingAES:       true,
+		EncryptUsing128BitKey: true,
+		UserAccessPermissions: PermissionsNone,
+		FileSystem:            afero.NewMemMapFs(),
 	}
 }
 

--- a/pkg/pdfcpu/context.go
+++ b/pkg/pdfcpu/context.go
@@ -3,11 +3,12 @@ package pdfcpu
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
 	"github.com/hhrutter/pdfcpu/pkg/log"
+
+	"github.com/spf13/afero"
 )
 
 // PDFContext represents the context for processing PDF files.
@@ -20,7 +21,7 @@ type PDFContext struct {
 }
 
 // NewPDFContext initializes a new PDFContext.
-func NewPDFContext(fileName string, file *os.File, config *Configuration) (*PDFContext, error) {
+func NewPDFContext(fileName string, file afero.File, config *Configuration) (*PDFContext, error) {
 
 	if config == nil {
 		config = NewDefaultConfiguration()
@@ -141,7 +142,7 @@ type ReadContext struct {
 
 	// The PDF-File which gets processed.
 	FileName string
-	File     *os.File
+	File     afero.File
 	FileSize int64
 
 	BinaryTotalSize     int64 // total stream data
@@ -160,7 +161,7 @@ type ReadContext struct {
 	XRefStreams      IntSet // All object numbers of any xref streams found.
 }
 
-func newReadContext(fileName string, file *os.File, fileSize int64) *ReadContext {
+func newReadContext(fileName string, file afero.File, fileSize int64) *ReadContext {
 	return &ReadContext{
 		FileName:      fileName,
 		File:          file,

--- a/pkg/pdfcpu/context.go
+++ b/pkg/pdfcpu/context.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 
 	"github.com/spf13/afero"
 )

--- a/pkg/pdfcpu/createAnnotations.go
+++ b/pkg/pdfcpu/createAnnotations.go
@@ -4,7 +4,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/hhrutter/pdfcpu/pkg/filter"
+	"github.com/trussworks/pdfcpu/pkg/filter"
 )
 
 // Functions needed to create a test.pdf that gets used for validation testing (see process_test.go)

--- a/pkg/pdfcpu/createTestPDF.go
+++ b/pkg/pdfcpu/createTestPDF.go
@@ -1750,5 +1750,5 @@ func CreateDemoPDF(xRefTable *XRefTable, dirName, fileName string) error {
 	ctx.Write.DirName = dirName
 	ctx.Write.FileName = fileName
 
-	return WritePDFFile(ctx)
+	return WritePDFFile(ctx, config)
 }

--- a/pkg/pdfcpu/createTestPDF.go
+++ b/pkg/pdfcpu/createTestPDF.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/hhrutter/pdfcpu/pkg/filter"
+	"github.com/trussworks/pdfcpu/pkg/filter"
 )
 
 const testAudioFileWAV = "testdata/test.wav"

--- a/pkg/pdfcpu/crypto.go
+++ b/pkg/pdfcpu/crypto.go
@@ -15,7 +15,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/dict.go
+++ b/pkg/pdfcpu/dict.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/equal.go
+++ b/pkg/pdfcpu/equal.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/extract.go
+++ b/pkg/pdfcpu/extract.go
@@ -3,8 +3,8 @@ package pdfcpu
 import (
 	"strings"
 
-	"github.com/hhrutter/pdfcpu/pkg/filter"
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/filter"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/filter.go
+++ b/pkg/pdfcpu/filter.go
@@ -6,8 +6,8 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/hhrutter/pdfcpu/pkg/filter"
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/filter"
+	"github.com/trussworks/pdfcpu/pkg/log"
 )
 
 func parmsForFilter(d *PDFDict) map[string]int {

--- a/pkg/pdfcpu/merge.go
+++ b/pkg/pdfcpu/merge.go
@@ -3,7 +3,7 @@ package pdfcpu
 import (
 	"sort"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 )
 
 func patchIndRef(indRef *PDFIndirectRef, lookup map[int]int) {

--- a/pkg/pdfcpu/nameTree.go
+++ b/pkg/pdfcpu/nameTree.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 )
 
 const maxEntries = 3

--- a/pkg/pdfcpu/optimize.go
+++ b/pkg/pdfcpu/optimize.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/read.go
+++ b/pkg/pdfcpu/read.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -24,7 +23,7 @@ func ReadPDFFile(fileName string, config *Configuration) (*PDFContext, error) {
 
 	log.Debug.Println("readPDFFile: begin")
 
-	file, err := os.Open(fileName)
+	file, err := config.FileSystem.Open(fileName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "can't open %q", fileName)
 	}

--- a/pkg/pdfcpu/read.go
+++ b/pkg/pdfcpu/read.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hhrutter/pdfcpu/pkg/filter"
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/filter"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/streamdict.go
+++ b/pkg/pdfcpu/streamdict.go
@@ -3,8 +3,8 @@ package pdfcpu
 import (
 	"fmt"
 
-	"github.com/hhrutter/pdfcpu/pkg/filter"
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/filter"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/utf16.go
+++ b/pkg/pdfcpu/utf16.go
@@ -8,7 +8,7 @@ import (
 
 	"strings"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/validateAnnotations.go
+++ b/pkg/pdfcpu/validateAnnotations.go
@@ -1,7 +1,7 @@
 package pdfcpu
 
 import (
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/validateFont.go
+++ b/pkg/pdfcpu/validateFont.go
@@ -1,7 +1,7 @@
 package pdfcpu
 
 import (
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/validateInfo.go
+++ b/pkg/pdfcpu/validateInfo.go
@@ -1,7 +1,7 @@
 package pdfcpu
 
 import (
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/validateObjects.go
+++ b/pkg/pdfcpu/validateObjects.go
@@ -3,7 +3,7 @@ package pdfcpu
 import (
 	"fmt"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/validatePages.go
+++ b/pkg/pdfcpu/validatePages.go
@@ -1,7 +1,7 @@
 package pdfcpu
 
 import (
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/validateProperties.go
+++ b/pkg/pdfcpu/validateProperties.go
@@ -1,7 +1,7 @@
 package pdfcpu
 
 import (
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/validateXObject.go
+++ b/pkg/pdfcpu/validateXObject.go
@@ -1,7 +1,7 @@
 package pdfcpu
 
 import (
-	"github.com/hhrutter/pdfcpu/pkg/filter"
+	"github.com/trussworks/pdfcpu/pkg/filter"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/validateXReftable.go
+++ b/pkg/pdfcpu/validateXReftable.go
@@ -1,7 +1,7 @@
 package pdfcpu
 
 import (
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/write.go
+++ b/pkg/pdfcpu/write.go
@@ -5,22 +5,22 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
 	"github.com/hhrutter/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
+	"github.com/spf13/afero"
 )
 
 // WritePDFFile generates a PDF file for the cross reference table contained in PDFContext.
-func WritePDFFile(ctx *PDFContext) error {
+func WritePDFFile(ctx *PDFContext, config *Configuration) error {
 
 	fileName := ctx.Write.DirName + ctx.Write.FileName
 
 	log.Info.Printf("writing to %s\n", fileName)
 
-	file, err := os.Create(fileName)
+	file, err := config.FileSystem.Create(fileName)
 	if err != nil {
 		return errors.Wrapf(err, "can't create %s\n%s", fileName, err)
 	}
@@ -939,7 +939,7 @@ func writeXRef(ctx *PDFContext) error {
 	return writeXRefTable(ctx)
 }
 
-func setFileSizeOfWrittenFile(w *WriteContext, f *os.File) error {
+func setFileSizeOfWrittenFile(w *WriteContext, f afero.File) error {
 
 	// Get file info for file just written but flush first to get correct file size.
 

--- a/pkg/pdfcpu/write.go
+++ b/pkg/pdfcpu/write.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 )

--- a/pkg/pdfcpu/writeImage.go
+++ b/pkg/pdfcpu/writeImage.go
@@ -6,8 +6,8 @@ import (
 	"image/png"
 	"os"
 
-	"github.com/hhrutter/pdfcpu/pkg/filter"
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/filter"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/writeInfo.go
+++ b/pkg/pdfcpu/writeInfo.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/writeObjects.go
+++ b/pkg/pdfcpu/writeObjects.go
@@ -3,7 +3,7 @@ package pdfcpu
 import (
 	"fmt"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/writePages.go
+++ b/pkg/pdfcpu/writePages.go
@@ -1,7 +1,7 @@
 package pdfcpu
 
 import (
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/writeStats.go
+++ b/pkg/pdfcpu/writeStats.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/pdfcpu/xreftable.go
+++ b/pkg/pdfcpu/xreftable.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hhrutter/pdfcpu/pkg/filter"
-	"github.com/hhrutter/pdfcpu/pkg/log"
+	"github.com/trussworks/pdfcpu/pkg/filter"
+	"github.com/trussworks/pdfcpu/pkg/log"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
This Pull Request adds support for the [Afero Filesystem](https://github.com/spf13/afero), which provides the capability to build and merge multiple PDF files in-memory.  This capability is incredibly useful for some web server scenarios.

The default is to still use the operating system file system, which should lead to zero changes in the CLI.  This PR passed the tests in the sub-packages `pdfcpu` and `api`.  Afero works on Mac OSX, Linux, and Windows, but there could be issues with other operating systems.